### PR TITLE
Add basic PyTorch example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Data and model checkpoints
+/data/
+*.pth
+
+# Environment files
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Deep Learning Sandbox
+
+This repository contains a simple setup to experiment with deep learning models using [PyTorch](https://pytorch.org/). The included example trains a multilayer perceptron (MLP) on the MNIST handwritten digit dataset.
+
+## Getting Started
+
+1. Create a Python virtual environment (optional but recommended).
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the training script:
+   ```bash
+   python src/train.py --epochs 5
+   ```
+
+Model weights will be saved to `mnist_mlp.pth` after training.
+
+Feel free to modify the model architecture in `src/model.py` or extend the training script for your own experiments.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+torch
+torchvision
+numpy

--- a/src/model.py
+++ b/src/model.py
@@ -1,0 +1,14 @@
+import torch.nn as nn
+
+class SimpleMLP(nn.Module):
+    def __init__(self, input_size=28*28, hidden_size=128, num_classes=10):
+        super(SimpleMLP, self).__init__()
+        self.model = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(input_size, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, num_classes)
+        )
+
+    def forward(self, x):
+        return self.model(x)

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,76 @@
+import argparse
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+from model import SimpleMLP
+
+
+def get_dataloaders(batch_size: int):
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ])
+    train_data = datasets.MNIST(root="data", train=True, download=True, transform=transform)
+    test_data = datasets.MNIST(root="data", train=False, download=True, transform=transform)
+    train_loader = DataLoader(train_data, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_data, batch_size=batch_size, shuffle=False)
+    return train_loader, test_loader
+
+
+def train(model: nn.Module, dataloader: DataLoader, criterion: nn.Module, optimizer: torch.optim.Optimizer, device: torch.device):
+    model.train()
+    total_loss = 0
+    for batch, (data, target) in enumerate(dataloader):
+        data, target = data.to(device), target.to(device)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = criterion(output, target)
+        loss.backward()
+        optimizer.step()
+        total_loss += loss.item()
+    return total_loss / len(dataloader)
+
+
+def test(model: nn.Module, dataloader: DataLoader, criterion: nn.Module, device: torch.device):
+    model.eval()
+    correct = 0
+    total_loss = 0
+    with torch.no_grad():
+        for data, target in dataloader:
+            data, target = data.to(device), target.to(device)
+            output = model(data)
+            loss = criterion(output, target)
+            total_loss += loss.item()
+            pred = output.argmax(dim=1)
+            correct += (pred == target).sum().item()
+    accuracy = correct / len(dataloader.dataset)
+    return total_loss / len(dataloader), accuracy
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train a simple MLP on MNIST")
+    parser.add_argument('--epochs', type=int, default=5, help='number of training epochs')
+    parser.add_argument('--batch-size', type=int, default=64, help='input batch size')
+    parser.add_argument('--lr', type=float, default=0.01, help='learning rate')
+    parser.add_argument('--hidden-size', type=int, default=128, help='number of hidden units')
+    args = parser.parse_args()
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    train_loader, test_loader = get_dataloaders(args.batch_size)
+
+    model = SimpleMLP(hidden_size=args.hidden_size).to(device)
+    optimizer = torch.optim.SGD(model.parameters(), lr=args.lr)
+    criterion = nn.CrossEntropyLoss()
+
+    for epoch in range(1, args.epochs + 1):
+        train_loss = train(model, train_loader, criterion, optimizer, device)
+        test_loss, accuracy = test(model, test_loader, criterion, device)
+        print(f"Epoch {epoch}: train loss={train_loss:.4f}, test loss={test_loss:.4f}, accuracy={accuracy*100:.2f}%")
+
+    torch.save(model.state_dict(), 'mnist_mlp.pth')
+    print('Model saved to mnist_mlp.pth')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add example code for training an MNIST MLP
- include requirements and ignore common artifacts
- document usage in README

## Testing
- `python -m py_compile src/model.py src/train.py`
- `python src/train.py --epochs 1 --batch-size 64` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68481de2ab988332860dff1ba29e1f28